### PR TITLE
DisplayMarkdownコンポーネントの追加

### DIFF
--- a/app/src/components/lib/DisplayMarkdown.tsx
+++ b/app/src/components/lib/DisplayMarkdown.tsx
@@ -1,0 +1,75 @@
+import Markdown from "react-markdown";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import {
+  vsDark,
+  vscDarkPlus,
+} from "react-syntax-highlighter/dist/cjs/styles/prism";
+import remarkGfm from "remark-gfm";
+
+import { IArticle } from "@/types/IArticle";
+
+interface ArticleType {
+  article: IArticle;
+  theme?: string;
+}
+
+const DisplayMarkdown = ({ article, theme = "light" }: ArticleType) => {
+  return (
+    <Markdown
+      components={{
+        h1(props) {
+          return (
+            <div>
+              <div className="mt-auto flex items-center gap-x-2 text-xs text-gray-400 dark:text-gray-400">
+                <time className="">{article.createdAt}</time>
+                {article.type === "articles" && (
+                  <>
+                    <div className="h-1 w-1 rounded-full bg-gray-400 dark:bg-gray-500"></div>
+                    <p>約{article.readingTime}分で読めます</p>
+                  </>
+                )}
+              </div>
+              <h1 {...props} />
+            </div>
+          );
+        },
+        img({ src, alt, ...props }) {
+          return (
+            <img
+              src={src}
+              alt={alt}
+              className="h-64 w-full object-cover"
+              {...props}
+            />
+          );
+        },
+        code(props) {
+          const { children, className, ...rest } = props;
+          const match = /language-(\w+)/.exec(className || "");
+          return match ? (
+            <SyntaxHighlighter
+              PreTag="div"
+              language={match[1]}
+              style={theme === "light" ? vscDarkPlus : vsDark}
+            >
+              {String(children).replace(/\n$/, "")}
+            </SyntaxHighlighter>
+          ) : (
+            <code {...rest} className={className}>
+              {children}
+            </code>
+          );
+        },
+      }}
+      className="prose prose-sm prose-gray max-w-none dark:prose-invert prose-pre:bg-white prose-pre:p-0 prose-thead:bg-gray-200 prose-th:px-2 prose-th:py-3 prose-td:px-2 dark:prose-pre:bg-gray-900 dark:prose-thead:bg-gray-800"
+      remarkPlugins={[remarkGfm]}
+      allowedElements={
+        article.type === "articles" ? undefined : ["h1", "pre", "code"]
+      }
+    >
+      {article.content}
+    </Markdown>
+  );
+};
+
+export default DisplayMarkdown;

--- a/app/src/components/model/Card/components/Card.tsx
+++ b/app/src/components/model/Card/components/Card.tsx
@@ -26,8 +26,12 @@ const Card = (props: Props) => {
             </h3>
             <div className="mt-auto flex items-center gap-x-2 text-xs text-gray-400 dark:text-gray-400">
               <time className="">{createdAt}</time>
-              <div className="h-1 w-1 rounded-full bg-gray-400 dark:bg-gray-500"></div>
-              <p>{readingTime}分で読めます</p>
+              {type === "articles" && (
+                <>
+                  <div className="h-1 w-1 rounded-full bg-gray-400 dark:bg-gray-500"></div>
+                  <p>約{readingTime}分で読めます</p>
+                </>
+              )}
             </div>
           </div>
         </Link>

--- a/app/src/contents/articles/test.md
+++ b/app/src/contents/articles/test.md
@@ -1,9 +1,7 @@
 ---
 title: 日本語フェイクニュースデータセット
 createdAt: 2023/03/14
-readingTime: 4
 publish: true
-type: "articles"
 ---
 # 日本語フェイクニュースデータセット
 

--- a/app/src/contents/snippets/install-vscode-on-archlinux.md
+++ b/app/src/contents/snippets/install-vscode-on-archlinux.md
@@ -1,9 +1,7 @@
 ---
 title: "Arch LinuxにVSCodeをインストールする方法"
 createdAt: 2023/03/14
-readingTime: 4
 publish: true
-type: "snippets"
 ---
 # Arch LinuxにVSCodeをインストールする方法
 

--- a/app/src/feature/Manager/manager.ts
+++ b/app/src/feature/Manager/manager.ts
@@ -3,7 +3,12 @@ import { join } from "path";
 
 import matter from "gray-matter";
 
-import { IArticleInfo, PrevAndNextArticleData } from "@/types/IArticle";
+import {
+  IArticleInfo,
+  IArticleType,
+  PrevAndNextArticleData,
+} from "@/types/IArticle";
+import removeMarkdownSyntax from "@/utility/removeMarkdownSyntax";
 
 class ManagerClass {
   private dirPath: string;
@@ -20,11 +25,19 @@ class ManagerClass {
           "utf-8",
         );
 
-        const { data } = matter(markdownData);
+        const type = this.dirPath.split("/")[
+          this.dirPath.split("/").length - 1
+        ] as IArticleType["type"];
+
+        const { data, content } = matter(markdownData);
+
+        const removedMarkdownSyntax = removeMarkdownSyntax(content);
 
         const result: IArticleInfo = {
           ...(<IArticleInfo>data),
           href: fileName.replace(/.md/, ""),
+          type: type,
+          readingTime: Math.floor(removedMarkdownSyntax.length / 400),
         };
 
         return result;
@@ -79,11 +92,19 @@ class ManagerClass {
       })
       .filter((v) => v) as PrevAndNextArticleData[];
 
+    const type = this.dirPath.split("/")[
+      this.dirPath.split("/").length - 1
+    ] as IArticleType["type"];
+
     const { data, content } = matter(markdownData);
+
+    const removedMarkdownSyntax = removeMarkdownSyntax(content);
 
     const result = {
       ...(<IArticleInfo>data),
       content: content,
+      type: type,
+      readingTime: Math.floor(removedMarkdownSyntax.length / 400),
     };
 
     return {

--- a/app/src/pages/articles/[article].tsx
+++ b/app/src/pages/articles/[article].tsx
@@ -1,11 +1,9 @@
 import Link from "next/link";
 import { HiChevronLeft, HiChevronRight } from "react-icons/hi2";
-import Markdown from "react-markdown";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism";
-import remarkGfm from "remark-gfm";
 
+import useDarkMode from "@/components/layout/Header/hooks/useDarkMode";
 import { Layout } from "@/components/layout/Layout";
+import DisplayMarkdown from "@/components/lib/DisplayMarkdown";
 import Manager from "@/feature/Manager";
 import { IArticle, PrevAndNextArticleData } from "@/types/IArticle";
 
@@ -20,57 +18,13 @@ interface PathType {
 }
 
 const Content = ({ article, prev, next }: ArticleType) => {
+  const { theme } = useDarkMode();
+
   return (
     <Layout title="R'IndiCode">
       <main className="flex min-h-[calc(100vh-49px)] w-full flex-col overflow-x-hidden px-5 pb-8 pt-20 dark:bg-gray-900">
         <article className="mb-4">
-          <Markdown
-            components={{
-              h1(props) {
-                return (
-                  <div>
-                    <div className="mt-auto flex items-center gap-x-2 text-xs text-gray-400 dark:text-gray-400">
-                      <time className="">{article.createdAt}</time>
-                      <div className="h-1 w-1 rounded-full bg-gray-400 dark:bg-gray-500"></div>
-                      <p>{article.readingTime}分で読めます</p>
-                    </div>
-                    <h1 {...props} />
-                  </div>
-                );
-              },
-              img({ src, alt, ...props }) {
-                return (
-                  <img
-                    src={src}
-                    alt={alt}
-                    className="h-64 w-full object-cover"
-                    {...props}
-                  />
-                );
-              },
-              code(props) {
-                const { children, className, ...rest } = props;
-                const match = /language-(\w+)/.exec(className || "");
-                return match ? (
-                  <SyntaxHighlighter
-                    PreTag="div"
-                    language={match[1]}
-                    style={vscDarkPlus}
-                  >
-                    {String(children).replace(/\n$/, "")}
-                  </SyntaxHighlighter>
-                ) : (
-                  <code {...rest} className={className}>
-                    {children}
-                  </code>
-                );
-              },
-            }}
-            className="prose prose-sm prose-gray max-w-none dark:prose-invert prose-pre:bg-white prose-pre:p-0 prose-thead:bg-gray-200 prose-th:px-2 prose-th:py-3 prose-td:px-2 dark:prose-pre:bg-gray-900 dark:prose-thead:bg-gray-800"
-            remarkPlugins={[remarkGfm]}
-          >
-            {article.content}
-          </Markdown>
+          <DisplayMarkdown article={article} theme={theme} />
         </article>
         <ul className="flex items-center justify-between gap-x-4 py-4">
           {prev && (

--- a/app/src/pages/snippets/[snippet].tsx
+++ b/app/src/pages/snippets/[snippet].tsx
@@ -1,11 +1,9 @@
 import Link from "next/link";
 import { HiChevronLeft, HiChevronRight } from "react-icons/hi2";
-import Markdown from "react-markdown";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism";
-import remarkGfm from "remark-gfm";
 
+import useDarkMode from "@/components/layout/Header/hooks/useDarkMode";
 import { Layout } from "@/components/layout/Layout";
+import DisplayMarkdown from "@/components/lib/DisplayMarkdown";
 import Manager from "@/feature/SnippetManager";
 import { IArticle, PrevAndNextArticleData } from "@/types/IArticle";
 
@@ -20,56 +18,13 @@ interface PathType {
 }
 
 const Content = ({ snippet, prev, next }: SnippetType) => {
+  const { theme } = useDarkMode();
+
   return (
     <Layout title="R'IndiCode">
       <main className="flex min-h-[calc(100vh-49px)] w-full flex-col overflow-x-hidden px-5 pb-8 pt-20 dark:bg-gray-900">
         <article className="mb-4">
-          <Markdown
-            allowedElements={["h1", "pre", "code"]}
-            components={{
-              h1(props) {
-                return (
-                  <div>
-                    <div className="mt-auto flex items-center gap-x-2 text-xs text-gray-400 dark:text-gray-400">
-                      <time className="">{snippet.createdAt}</time>
-                    </div>
-                    <h1 {...props} />
-                  </div>
-                );
-              },
-              img({ src, alt, ...props }) {
-                return (
-                  <img
-                    src={src}
-                    alt={alt}
-                    className="h-64 w-full object-cover"
-                    {...props}
-                  />
-                );
-              },
-              code(props) {
-                const { children, className, ...rest } = props;
-                const match = /language-(\w+)/.exec(className || "");
-                return match ? (
-                  <SyntaxHighlighter
-                    PreTag="div"
-                    language={match[1]}
-                    style={vscDarkPlus}
-                  >
-                    {String(children).replace(/\n$/, "")}
-                  </SyntaxHighlighter>
-                ) : (
-                  <code {...rest} className={className}>
-                    {children}
-                  </code>
-                );
-              },
-            }}
-            className="prose prose-sm prose-gray max-w-none dark:prose-invert prose-pre:bg-white prose-pre:p-0 prose-thead:bg-gray-200 prose-th:px-2 prose-th:py-3 prose-td:px-2 dark:prose-pre:bg-gray-900 dark:prose-thead:bg-gray-800"
-            remarkPlugins={[remarkGfm]}
-          >
-            {snippet.content}
-          </Markdown>
+          <DisplayMarkdown article={snippet} theme={theme} />
         </article>
         <ul className="flex items-center justify-between gap-x-4 py-4">
           {prev && (

--- a/app/src/test/articles/test.md
+++ b/app/src/test/articles/test.md
@@ -1,7 +1,6 @@
 ---
 title: 日本語フェイクニュースデータセット
 createdAt: 2023/03/14
-readingTime: 4
 publish: true
 ---
 # 日本語フェイクニュースデータセット

--- a/app/src/test/node/ArticleApi.test.ts
+++ b/app/src/test/node/ArticleApi.test.ts
@@ -28,7 +28,8 @@ describe("Manager test", () => {
       "日本語フェイクニュースデータセット",
     );
     expect(article).toHaveProperty("createdAt", "2023/03/14");
-    expect(article).toHaveProperty("readingTime", 4);
+    expect(article).toHaveProperty("readingTime", 6);
+    expect(article).toHaveProperty("type", "articles");
     expect(article).toHaveProperty("publish", true);
     expect(article).toHaveProperty(
       "content",

--- a/app/src/types/IArticle.ts
+++ b/app/src/types/IArticle.ts
@@ -1,4 +1,4 @@
-export interface IArticleInfo {
+export interface IArticleInfo extends IArticleType {
   href: string;
   src: string;
   alt: string;
@@ -6,11 +6,14 @@ export interface IArticleInfo {
   readingTime: number;
   createdAt: string;
   publish: boolean;
-  type: "articles" | "snippets";
 }
 
 export interface IArticle extends IArticleInfo {
   content: string;
+}
+
+export interface IArticleType {
+  type: "articles" | "snippets";
 }
 
 export interface PrevAndNextArticleData {

--- a/app/src/utility/removeMarkdownSyntax.ts
+++ b/app/src/utility/removeMarkdownSyntax.ts
@@ -1,0 +1,7 @@
+const removeMarkdownSyntax = (content: string) => {
+  const markdownSyntax =
+    /([*_~`|\-]|#+\s|<br>|!\[.*?\]\(.*?\)|\[.*?\]\(.*?\))/g;
+  return content.replace(markdownSyntax, "");
+};
+
+export default removeMarkdownSyntax;


### PR DESCRIPTION
- 記事を取得する際、タイプがarticlesかsnippetsか追加するようコードを修正
- ↑の時、コンテンツの文字数から何分で読めるかを計算するようにコードを修正
- マークダウンを表示するDisplayMarkdownコンポーネントの追加